### PR TITLE
Load eBay credentials from secrets file

### DIFF
--- a/List_Slabs.bat
+++ b/List_Slabs.bat
@@ -2,12 +2,15 @@
 setlocal ENABLEDELAYEDEXPANSION
 
 REM =======================
-REM  USER CONFIG (YOUR APP)
+REM  LOAD CREDENTIALS
 REM =======================
-set "EBAY_CLIENT_ID=JohnClar-p-PRD-c8135f6e7-528be997"
-set "EBAY_CLIENT_SECRET=PRD-8135f6e740de-933c-4107-8bdb-01b0"
-set "EBAY_REFRESH_TOKEN=v^1.1#i^1#r^1#f^0#I^3#p^3#t^Ul4xMF8zOjQzMTUxM0E4OEYzNUUxRTEzNzY2NjFDRURBNURGQkRCXzFfMSNFXjI2MA=="
-set "EBAY_RETURN_POLICY_ID=272036672014"
+if not exist "secrets.env" (
+  echo ERROR: secrets.env not found
+  pause & exit /b 1
+)
+for /f "usebackq tokens=1* delims== eol=#" %%A in ("secrets.env") do (
+  set "%%A=%%B"
+)
 
 REM =======================
 REM  PATHS (EDIT IF NEEDED)
@@ -43,6 +46,10 @@ REM =======================================================
 if "%EBAY_CLIENT_ID%"=="" (echo ERROR: EBAY_CLIENT_ID is blank& pause & exit /b 1)
 if "%EBAY_CLIENT_SECRET%"=="" (echo ERROR: EBAY_CLIENT_SECRET is blank& pause & exit /b 1)
 if "%EBAY_REFRESH_TOKEN%"=="" (echo ERROR: EBAY_REFRESH_TOKEN is blank& pause & exit /b 1)
+if "%EBAY_RETURN_POLICY_ID%"=="" (echo ERROR: EBAY_RETURN_POLICY_ID is blank& pause & exit /b 1)
+if "%EBAY_PAYMENT_POLICY_ID%"=="" (echo ERROR: EBAY_PAYMENT_POLICY_ID is blank& pause & exit /b 1)
+if "%EBAY_FULFILLMENT_POLICY_ID%"=="" (echo ERROR: EBAY_FULFILLMENT_POLICY_ID is blank& pause & exit /b 1)
+if "%EBAY_LOCATION_ID%"=="" (echo ERROR: EBAY_LOCATION_ID is blank& pause & exit /b 1)
 
 for /f "usebackq delims=" %%A in (`powershell -NoProfile -ExecutionPolicy Bypass ^
   -Command ^
@@ -65,9 +72,6 @@ if "%ACCESS_TOKEN%"=="" (
 
 REM Export token + common vars so PowerShell scripts can read them
 set "ACCESS_TOKEN=%ACCESS_TOKEN%"
-if "%EBAY_PAYMENT_POLICY_ID%"=="" set EBAY_PAYMENT_POLICY_ID=272036644014
-if "%EBAY_FULFILLMENT_POLICY_ID%"=="" set EBAY_FULFILLMENT_POLICY_ID=272036663014
-if "%EBAY_LOCATION_ID%"=="" set EBAY_LOCATION_ID=POKESLABS_US
 set "CSV_PATH=%CSV%"
 set "IMAGES_DIR=%IMGDIR%"
 

--- a/README_AUCTION.md
+++ b/README_AUCTION.md
@@ -15,6 +15,21 @@ This package switches listings to **7‑day AUCTIONS** and ensures the three scr
 - Titles: language tag `[EN]`/`[JP]` after card name
 - SKU: optional/blank; falls back to `{grader}-{cert_number}` only if required
 
+## Credentials
+Create a `secrets.env` file in the repository root with your eBay credentials and policy IDs. Each line should follow `KEY=VALUE` format:
+
+```
+EBAY_CLIENT_ID=your-app-id
+EBAY_CLIENT_SECRET=your-app-secret
+EBAY_REFRESH_TOKEN=your-refresh-token
+EBAY_PAYMENT_POLICY_ID=your-payment-policy-id
+EBAY_FULFILLMENT_POLICY_ID=your-fulfillment-policy-id
+EBAY_RETURN_POLICY_ID=your-return-policy-id
+EBAY_LOCATION_ID=your-location-id
+```
+
+`List_Slabs.bat` loads these values and uses them when invoking the PowerShell scripts. The file is already ignored by git.
+
 ## Environment variables (optional)
 - `CSV_PATH` → path to `master.csv` (if not passing `-CsvPath`)
 - `IMAGES_SRC` → source root where your iPhone photos live (USB/DCIM path)

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,0 +1,8 @@
+# Copy to secrets.env and fill in your credentials
+EBAY_CLIENT_ID=your-app-id
+EBAY_CLIENT_SECRET=your-app-secret
+EBAY_REFRESH_TOKEN=your-refresh-token
+EBAY_PAYMENT_POLICY_ID=your-payment-policy-id
+EBAY_FULFILLMENT_POLICY_ID=your-fulfillment-policy-id
+EBAY_RETURN_POLICY_ID=your-return-policy-id
+EBAY_LOCATION_ID=your-location-id


### PR DESCRIPTION
## Summary
- Read eBay credential and policy IDs from `secrets.env` instead of hardcoding them
- Document secret credential setup in README and add example `secrets.env.example`

## Testing
- `pwsh -NoLogo -Command "Write-Output 'PowerShell available'"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6bb97d0c832eabf87d8153486151