### PR TITLE
chore: improve listing batch orchestration

### DIFF
--- a/List_Slabs.bat
+++ b/List_Slabs.bat
@@ -1,7 +1,6 @@
 @echo off
+cd /d "%~dp0"  REM Ensure we run from the script directory
 setlocal ENABLEDELAYEDEXPANSION
-REM Ensure we run from the script directory
-cd /d "%~dp0"
 
 set "SECRETS=%~dp0secrets.env"
 if not exist "%SECRETS%" (
@@ -20,14 +19,15 @@ for %%V in (EBAY_CLIENT_ID EBAY_CLIENT_SECRET EBAY_REFRESH_TOKEN EBAY_LOCATION_I
 if "%EBAY_ENV%"=="" set EBAY_ENV=test
 if "%BASEDIR%"=="" set "BASEDIR=C:\Users\johnr\Documents\ebay"
 if "%LISTING_FORMAT%"=="" set "LISTING_FORMAT=AUCTION"
+if "%LISTING_DURATION_DAYS%"=="" set "LISTING_DURATION_DAYS=7"
 
 set "CSV=%BASEDIR%\master.csv"
 set "IMGDIR=%BASEDIR%\Images"
-set "LOGDIR=%BASEDIR%\logs"
-set "OUTMAP=%BASEDIR%\eps_image_map.json"
 set "PULL_SCRIPT=%~dp0Pull-Photos-FromMasterCSV.ps1"
 set "EPS_SCRIPT=%~dp0eps_uploader.ps1"
 set "LISTER_SCRIPT=%~dp0lister.ps1"
+set "LOGDIR=%BASEDIR%\logs"
+set "OUTMAP=%BASEDIR%\eps_image_map.json"
 
 if not exist "%CSV%" (
   echo ERROR: master.csv not found at %CSV%
@@ -51,15 +51,15 @@ if not exist "%LISTER_SCRIPT%" (
 )
 
 if not exist "%LOGDIR%" mkdir "%LOGDIR%" >nul 2>&1
-for /f %%I in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "STAMP=%%I"
+for /f %%A in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd_HHmmss"') do set "STAMP=%%A"
 set "LOG=%LOGDIR%\run_%STAMP%.log"
 
-set "RUNARGS=-DryRun"
-if /I "%1"=="live" set "RUNARGS="
+set "RUNMODE=-DryRun"
+if /I "%~1"=="live" set "RUNMODE="
 
 REM Obtain OAuth token when running live
-if /I "%1"=="live" (
-  powershell -NoProfile -Command "$pair=\"${env:EBAY_CLIENT_ID}:${env:EBAY_CLIENT_SECRET}\"; $basic=[Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($pair)); $headers=@{Authorization=\"Basic $basic\"}; $scope='https://api.ebay.com/oauth/api_scope https://api.ebay.com/oauth/api_scope/sell.inventory https://api.ebay.com/oauth/api_scope/sell.account https://api.ebay.com/oauth/api_scope/sell.fulfillment'; $body=@{grant_type='refresh_token';refresh_token=$env:EBAY_REFRESH_TOKEN;scope=$scope}; try { $resp=Invoke-RestMethod -Method Post -Uri 'https://api.ebay.com/identity/v1/oauth2/token' -Headers $headers -Body $body -ContentType 'application/x-www-form-urlencoded'; $resp.access_token >'$LOGDIR\token.tmp' } catch { $_ | Out-String | Add-Content '$LOG'; exit 1 }" >>"%LOG%" 2>>&1
+if /I "%~1"=="live" (
+  powershell -NoProfile -Command "$pair=\"${env:EBAY_CLIENT_ID}:${env:EBAY_CLIENT_SECRET}\"; $basic=[Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($pair)); $headers=@{Authorization=\"Basic $basic\"}; $scope='https://api.ebay.com/oauth/api_scope https://api.ebay.com/oauth/api_scope/sell.inventory https://api.ebay.com/oauth/api_scope/sell.account https://api.ebay.com/oauth/api_scope/sell.fulfillment'; $body=@{grant_type='refresh_token';refresh_token=$env:EBAY_REFRESH_TOKEN;scope=$scope}; try { $resp=Invoke-RestMethod -Method Post -Uri 'https://api.ebay.com/identity/v1/oauth2/token' -Headers $headers -Body $body -ContentType 'application/x-www-form-urlencoded'; $resp.access_token >'$LOGDIR\token.tmp' } catch { $_ | Out-String | Add-Content '$LOG'; exit 1 }" 1>>"%LOG%" 2>>&1
   if errorlevel 1 goto :failure
   set /p ACCESS_TOKEN=<"%LOGDIR%\token.tmp"
   del "%LOGDIR%\token.tmp"
@@ -67,11 +67,12 @@ if /I "%1"=="live" (
 ) else (
   set "ACCESS_TOKEN=dummy"
 )
-call :RunStep "Pull photos" powershell -NoProfile -ExecutionPolicy Bypass -File "%PULL_SCRIPT%" -CsvPath "%CSV%" -DestDir "%IMGDIR%"
+set "ACCESS_TOKEN=%ACCESS_TOKEN%"
+call :RunStep "Step 0 (photo pull)" powershell -NoProfile -ExecutionPolicy Bypass -File "%PULL_SCRIPT%" -CsvPath "%CSV%" -DestDir "%IMGDIR%"
 if errorlevel 1 goto :failure
-call :RunStep "Upload EPS" powershell -NoProfile -ExecutionPolicy Bypass -File "%EPS_SCRIPT%" -CsvPath "%CSV%" -ImagesDir "%IMGDIR%" -AccessToken "%ACCESS_TOKEN%" -OutMap "%OUTMAP%" %RUNARGS%
+call :RunStep "Step 1 (EPS)" powershell -NoProfile -ExecutionPolicy Bypass -File "%EPS_SCRIPT%" -CsvPath "%CSV%" -ImagesDir "%IMGDIR%" -AccessToken "%ACCESS_TOKEN%" -OutMap "%OUTMAP%" %RUNMODE%
 if errorlevel 1 goto :failure
-call :RunStep "Create listings" powershell -NoProfile -ExecutionPolicy Bypass -File "%LISTER_SCRIPT%" -CsvPath "%CSV%" -AccessToken "%ACCESS_TOKEN%" -ImageMap "%OUTMAP%" -ListingFormat "%LISTING_FORMAT%" %RUNARGS%
+call :RunStep "Step 2 (Lister)" powershell -NoProfile -ExecutionPolicy Bypass -File "%LISTER_SCRIPT%" -CsvPath "%CSV%" -AccessToken "%ACCESS_TOKEN%" -ImageMap "%OUTMAP%" -ListingFormat "%LISTING_FORMAT%" -ListingDurationDays "%LISTING_DURATION_DAYS%" %RUNMODE%
 if errorlevel 1 goto :failure
 
 echo Done. Log: %LOG%
@@ -80,7 +81,9 @@ exit /b 0
 :RunStep
 set "STEP=%~1"
 shift
-%* >>"%LOG%" 2>>&1
+echo.>>"%LOG%"
+echo ===== [%DATE% %TIME%] %STEP% =====>>"%LOG%"
+%* 1>>"%LOG%" 2>>&1
 exit /b %errorlevel%
 
 :failure


### PR DESCRIPTION
## Summary
- add RUNMODE parsing and listing duration defaults
- centralize step logging with banners and failure trap
- ensure paths and OAuth token are prepared before executing PowerShell steps

## Testing
- `python tests/dryrun_validate.py`
- `cmd.exe /c List_Slabs.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abbec25210832eaa222093d5920a79