### PR TITLE
Fix variable colon parsing in photo pull and uploader scripts

### DIFF
--- a/Pull-Photos-FromMasterCSV.ps1
+++ b/Pull-Photos-FromMasterCSV.ps1
@@ -38,9 +38,9 @@ foreach ($row in $rows) {
     }
   }
   if ($rowMissing.Count -eq 0) {
-    Write-Host "$label: OK"
+    Write-Host "${label}: OK"
   } else {
-    Write-Host "$label: missing $($rowMissing -join ', ')"
+    Write-Host "${label}: missing $($rowMissing -join ', ')"
   }
 }
 if ($missing.Count -gt 0) {

--- a/eps_uploader.ps1
+++ b/eps_uploader.ps1
@@ -90,7 +90,7 @@ foreach ($name in $filenames) {
     exit 1
   }
   if (-not ($url -like 'https://*')) {
-    Write-Error "Non-HTTPS URL returned for $name: $url"
+    Write-Error "Non-HTTPS URL returned for ${name}: $url"
     exit 1
   }
   $imgMap[$name] = $url


### PR DESCRIPTION
## Summary
- guard PowerShell variable names followed by colons using braces to avoid parser errors
- scan repo for similar patterns and update eps_uploader

## Testing
- `bash List_Slabs.bat` *(fails: @echo command not found)*
- `bash List_Slabs.bat live` *(fails: @echo command not found)*
- `python tests/dryrun_validate.py`


------
https://chatgpt.com/codex/tasks/task_e_68abfce883ac832eb479cd15f83d4b36