### PR TITLE
Enable automatic iPhone photo discovery for Step 0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@
 - **Publish:** run `List_Slabs.bat live` (requires secrets, `EBAY_ENV=prod`, and `.ebay-live.ok`).
 - **Logs:** see `logs/run_YYYYMMDD_HHmmss.log`; scripts exit non-zero on failure.
 - **Common failures:** missing image filenames, unmapped YAML values, inventory location or policy ID mismatches.
+- **Photos source resolution:** Step 0 searches `PHOTOS_SRC` (semicolon-separated folders) recursively. If `PHOTOS_SRC` is unset or set to `auto`, it auto-discovers an attached iPhone under `This PC\Apple iPhone\Internal Storage\DCIM` and copies matching filenames. Locked or hidden devices cause a fail-fast message to unlock the phone.

--- a/List_Slabs.bat
+++ b/List_Slabs.bat
@@ -24,6 +24,7 @@ if "%LISTING_DURATION_DAYS%"=="" set "LISTING_DURATION_DAYS=7"
 
 set "CSV=%BASEDIR%\master.csv"
 set "IMGDIR=%BASEDIR%\Images"
+if "%PHOTOS_SRC%"=="" set "PHOTOS_SRC=%IMGDIR%"
 set "PULL_SCRIPT=%~dp0Pull-Photos-FromMasterCSV.ps1"
 set "EPS_SCRIPT=%~dp0eps_uploader.ps1"
 set "LISTER_SCRIPT=%~dp0lister.ps1"

--- a/Pull-Photos-FromMasterCSV.ps1
+++ b/Pull-Photos-FromMasterCSV.ps1
@@ -10,39 +10,169 @@ $cols = @('Image_Front','Image_Back','TopFrontImage','TopBackImage')
 if (-not (Test-Path $CsvPath)) { throw "CSV not found: $CsvPath" }
 if (-not (Test-Path $DestDir)) { New-Item -ItemType Directory -Path $DestDir | Out-Null }
 
-$sources = $env:PHOTOS_SRC -split ';' | Where-Object { $_ }
-if (-not $sources) { throw 'PHOTOS_SRC environment variable not set' }
-foreach ($s in $sources) { if (-not (Test-Path $s)) { throw "Source directory not found: $s" } }
+# parse sources and MTP auto mode
+$sources = @()
+$useMtp = $false
+if ($env:PHOTOS_SRC) {
+  foreach ($part in $env:PHOTOS_SRC -split ';') {
+    $p = $part.Trim()
+    if (-not $p) { continue }
+    if ($p.ToLower() -eq 'auto') { $useMtp = $true } else { $sources += $p }
+  }
+} else {
+  $useMtp = $true
+}
+foreach ($s in $sources) {
+  if (-not (Test-Path $s)) { throw "Source directory not found: $s" }
+}
+
+function Find-LocalFile {
+  param([string]$Name, [string[]]$Roots)
+  foreach ($root in $Roots) {
+    $match = Get-ChildItem -Path $root -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -ieq $Name } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+    if ($match) { return $match.FullName }
+  }
+  return $null
+}
+
+function Build-MtpIndex {
+  param([System.Collections.Generic.HashSet[string]]$Targets)
+  $shell = New-Object -ComObject Shell.Application
+  $myComputer = $shell.Namespace(0x11)
+  $deviceItem = $null
+  foreach ($i in @($myComputer.Items())) {
+    if ($i.Name -match 'iPhone' -or $i.Name -match 'Apple') { $deviceItem = $i; break }
+  }
+  if (-not $deviceItem) {
+    Write-Error "iPhone not accessible. Unlock the device and confirm 'Internal Storage\\DCIM' is visible in Explorer."
+    exit 1
+  }
+  $device = $deviceItem.GetFolder()
+  $internalItem = $device.ParseName('Internal Storage')
+  if (-not $internalItem) {
+    Write-Error "iPhone not accessible. Unlock the device and confirm 'Internal Storage\\DCIM' is visible in Explorer."
+    exit 1
+  }
+  $dcimItem = $internalItem.GetFolder().ParseName('DCIM')
+  if (-not $dcimItem) {
+    Write-Error "iPhone not accessible. Unlock the device and confirm 'Internal Storage\\DCIM' is visible in Explorer."
+    exit 1
+  }
+  $dcim = $dcimItem.GetFolder()
+  $index = @{}
+  foreach ($t in $Targets) { $index[$t.ToLower()] = New-Object System.Collections.ArrayList }
+  $queue = New-Object System.Collections.Generic.Queue[Object]
+  $queue.Enqueue($dcim)
+  $any = $false
+  while ($queue.Count -gt 0) {
+    $folder = $queue.Dequeue()
+    foreach ($item in @($folder.Items())) {
+      if ($item.IsFolder) {
+        $queue.Enqueue($item.GetFolder())
+      } else {
+        $any = $true
+        $name = $item.Name.ToLower()
+        if ($index.ContainsKey($name)) { $index[$name].Add($item) | Out-Null }
+      }
+    }
+  }
+  if (-not $any) {
+    Write-Error "iPhone not accessible. Unlock the device and confirm 'Internal Storage\\DCIM' is visible in Explorer."
+    exit 1
+  }
+  Write-Host ("MTP mode: device '{0}' detected" -f $deviceItem.Name)
+  return @{ Shell = $shell; Index = $index }
+}
+
+function Get-BestMtpItem {
+  param([string]$Name, $Index)
+  $list = $Index[$Name.ToLower()]
+  if (-not $list -or $list.Count -eq 0) { return $null }
+  $best = $null
+  $bestDate = $null
+  $bestSize = 0
+  foreach ($item in $list) {
+    $date = $item.ExtendedProperty('System.DateModified')
+    if (-not $date) { $date = $item.ExtendedProperty('System.DateCreated') }
+    $size = $item.ExtendedProperty('System.Size')
+    if (-not $best) {
+      $best = $item; $bestDate = $date; $bestSize = $size; continue
+    }
+    if ($date -and $bestDate) {
+      if ($date -gt $bestDate) { $best = $item; $bestDate = $date; $bestSize = $size }
+    } elseif ($date -and -not $bestDate) {
+      $best = $item; $bestDate = $date; $bestSize = $size
+    } elseif (-not $date -and -not $bestDate) {
+      if ($size -gt $bestSize) { $best = $item; $bestSize = $size }
+    }
+  }
+  return $best
+}
 
 $rows = Import-Csv -Path $CsvPath
+$targets = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+foreach ($row in $rows) {
+  foreach ($col in $cols) {
+    if ($row.PSObject.Properties.Name -contains $col) {
+      $fname = $row.$col
+      if (-not [string]::IsNullOrWhiteSpace($fname)) { $targets.Add($fname) | Out-Null }
+    }
+  }
+}
+$mtp = $null
+if ($useMtp) { $mtp = Build-MtpIndex $targets }
+$destNs = $null
+if ($mtp) { $destNs = $mtp.Shell.Namespace($DestDir) }
+
 $missing = [System.Collections.Generic.HashSet[string]]::new()
+$copied = 0
+$already = 0
 $rowNum = 0
 foreach ($row in $rows) {
   $rowNum++
   $label = if ($row.CertNumber) { $row.CertNumber } elseif ($row.SKU) { $row.SKU } else { "Row $rowNum" }
-  $rowMissing = @()
+  $rowMsgs = @()
   foreach ($col in $cols) {
     if (-not ($row.PSObject.Properties.Name -contains $col)) { continue }
     $fname = $row.$col
     if ([string]::IsNullOrWhiteSpace($fname)) { continue }
-    $found = $null
-    foreach ($root in $sources) {
-      $candidate = Join-Path $root $fname
-      if (Test-Path $candidate) { $found = $candidate; break }
-    }
+    $destPath = Join-Path $DestDir $fname
+    if (Test-Path $destPath) { $already++; $rowMsgs += "already had $fname"; continue }
+    $found = Find-LocalFile -Name $fname -Roots $sources
     if ($found) {
-      Copy-Item -LiteralPath $found -Destination (Join-Path $DestDir $fname) -Force
-    } else {
-      $rowMissing += $fname
-      $missing.Add($fname) | Out-Null
+      Copy-Item -LiteralPath $found -Destination $destPath -Force
+      if (Test-Path $destPath) {
+        $copied++
+        $rowMsgs += ("copied {0} from {1}" -f $fname, (Split-Path $found -Parent | Split-Path -Leaf))
+        continue
+      }
     }
+    if ($mtp) {
+      $item = Get-BestMtpItem -Name $fname -Index $mtp.Index
+      if ($item) {
+        $destNs.CopyHere($item, 20)
+        Start-Sleep -Milliseconds 200
+        if (Test-Path $destPath) {
+          $copied++
+          $parent = (Split-Path $item.Path -Parent | Split-Path -Leaf)
+          $rowMsgs += ("copied {0} from {1}" -f $fname, $parent)
+          continue
+        }
+      }
+    }
+    $missing.Add($fname) | Out-Null
+    $rowMsgs += "missing $fname"
   }
-  if ($rowMissing.Count -eq 0) {
-    Write-Host "$label: OK"
+  if ($rowMsgs.Count -gt 0) {
+    Write-Host ("{0}: {1}" -f $label, ($rowMsgs -join '; '))
   } else {
-    Write-Host "$label: missing $($rowMissing -join ', ')"
+    Write-Host ("{0}: no images" -f $label)
   }
 }
+Write-Host ("Summary: copied {0}, already present {1}, missing {2}" -f $copied, $already, $missing.Count)
 if ($missing.Count -gt 0) {
   Write-Error ("Missing {0} file(s): {1}" -f $missing.Count, ([string]::Join(', ',$missing)))
   exit 1

--- a/README_AUCTION.md
+++ b/README_AUCTION.md
@@ -29,6 +29,7 @@ Shipped quickly and securely in a bubble mailer with ding defender
 1. Copy iPhone photos named in `master.csv` into the local `Images/` folder.
 2. Upload only uncached photos to eBay Picture Services, storing HTTPS URLs in `eps_image_map.json`.
 3. Create inventory items and offers, then publish them to eBay.
+- If `PHOTOS_SRC` is unset or set to `auto`, Step 0 auto-discovers an attached iPhone under `Internal Storage\DCIM`; otherwise it recurses the folders listed in `PHOTOS_SRC`.
 
 The batch script logs each step to `logs/run_YYYYMMDD_HHMMSS.log` and stops on the first error.
 

--- a/eps_uploader.ps1
+++ b/eps_uploader.ps1
@@ -90,7 +90,7 @@ foreach ($name in $filenames) {
     exit 1
   }
   if (-not ($url -like 'https://*')) {
-    Write-Error "Non-HTTPS URL returned for $name: $url"
+    Write-Error "Non-HTTPS URL returned for ${name}: $url"
     exit 1
   }
   $imgMap[$name] = $url

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -13,3 +13,6 @@ EBAY_MARKETPLACE_ID=EBAY_US
 BASEDIR=C:\Users\johnr\Documents\ebay
 LISTING_FORMAT=AUCTION
 LISTING_DURATION_DAYS=7
+# Semicolon-separated photo source directories
+PHOTOS_SRC=C:\Users\johnr\Documents\ebay\Images
+


### PR DESCRIPTION
## Summary
- add MTP-based photo search when `PHOTOS_SRC` is unset or `auto`
- document auto photo source resolution in README and AGENTS notes

## Testing
- `python tests/dryrun_validate.py`


------
https://chatgpt.com/codex/tasks/task_e_68abfce883ac832eb479cd15f83d4b36