### PR TITLE
Remove iPhone photo pull step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,4 +29,4 @@
 - **Publish:** run `List_Slabs.bat live` (requires secrets, `EBAY_ENV=prod`, and `.ebay-live.ok`).
 - **Logs:** see `logs/run_YYYYMMDD_HHmmss.log`; scripts exit non-zero on failure.
 - **Common failures:** missing image filenames, unmapped YAML values, inventory location or policy ID mismatches.
-- **Photos source resolution:** Step 0 searches `PHOTOS_SRC` (semicolon-separated folders) recursively. If `PHOTOS_SRC` is unset or set to `auto`, it auto-discovers an attached iPhone under `This PC\Apple iPhone\Internal Storage\DCIM` and copies matching filenames. Locked or hidden devices cause a fail-fast message to unlock the phone.
+- **Photos:** Images referenced in `master.csv` must already exist in the `Images/` folder; the scripts no longer pull photos from attached devices.

--- a/List_Slabs.bat
+++ b/List_Slabs.bat
@@ -24,8 +24,6 @@ if "%LISTING_DURATION_DAYS%"=="" set "LISTING_DURATION_DAYS=7"
 
 set "CSV=%BASEDIR%\master.csv"
 set "IMGDIR=%BASEDIR%\Images"
-if "%PHOTOS_SRC%"=="" set "PHOTOS_SRC=%IMGDIR%"
-set "PULL_SCRIPT=%~dp0Pull-Photos-FromMasterCSV.ps1"
 set "EPS_SCRIPT=%~dp0eps_uploader.ps1"
 set "LISTER_SCRIPT=%~dp0lister.ps1"
 set "LOGDIR=%BASEDIR%\logs"
@@ -37,10 +35,6 @@ if not exist "%CSV%" (
 )
 if not exist "%IMGDIR%" (
   echo ERROR: Images directory not found at %IMGDIR%
-  exit /b 1
-)
-if not exist "%PULL_SCRIPT%" (
-  echo ERROR: missing Pull-Photos-FromMasterCSV.ps1
   exit /b 1
 )
 if not exist "%EPS_SCRIPT%" (
@@ -81,10 +75,6 @@ del "%LOGDIR%\token.tmp" 2>nul
 goto :after_oauth
 
 :after_oauth
-call :RunStep "Step 0 (photo pull)"
-powershell -NoProfile -ExecutionPolicy Bypass -File "%PULL_SCRIPT%" -CsvPath "%CSV%" -DestDir "%IMGDIR%" 1>>"%LOG%" 2>>&1
-if errorlevel 1 goto :failure
-
 call :RunStep "Step 1 (EPS)"
 powershell -NoProfile -ExecutionPolicy Bypass -File "%EPS_SCRIPT%" -CsvPath "%CSV%" -ImagesDir "%IMGDIR%" -AccessToken "%ACCESS_TOKEN%" -OutMap "%OUTMAP%" %RUNMODE% 1>>"%LOG%" 2>>&1
 if errorlevel 1 goto :failure

--- a/README_AUCTION.md
+++ b/README_AUCTION.md
@@ -26,12 +26,10 @@ Shipped quickly and securely in a bubble mailer with ding defender
 
 ## End-to-end flow
 `List_Slabs.bat` orchestrates a full run:
-1. Copy iPhone photos named in `master.csv` into the local `Images/` folder.
-2. Upload only uncached photos to eBay Picture Services, storing HTTPS URLs in `eps_image_map.json`.
-3. Create inventory items and offers, then publish them to eBay.
-- If `PHOTOS_SRC` is unset or set to `auto`, Step 0 auto-discovers an attached iPhone under `Internal Storage\DCIM`; otherwise it recurses the folders listed in `PHOTOS_SRC`.
+1. Upload only uncached photos to eBay Picture Services, storing HTTPS URLs in `eps_image_map.json`.
+2. Create inventory items and offers, then publish them to eBay.
 
-The batch script logs each step to `logs/run_YYYYMMDD_HHMMSS.log` and stops on the first error.
+The `Images/` folder must already contain the JPEG files referenced in `master.csv`. The batch script logs each step to `logs/run_YYYYMMDD_HHMMSS.log` and stops on the first error.
 
 ## Configuration
 Populate `secrets.env` (never committed) with required credentials and optional overrides. Key options:


### PR DESCRIPTION
## Summary
- Assume auction images already exist in `Images/` and drop the iPhone pull step from `List_Slabs.bat`.
- Document that image files must be preloaded and update AGENTS guidelines accordingly.

## Testing
- `python tests/dryrun_validate.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae34b53cf4832eb2809bec7d717cf9